### PR TITLE
Add documentation for directory filter

### DIFF
--- a/src/guide/command-line-options.md
+++ b/src/guide/command-line-options.md
@@ -20,6 +20,11 @@ infection --filter=src/Service/Mailer.php
 infection --filter=Mailer.php
 ```
 
+- a relative directory path:
+``` bash
+infection --filter=src/Service/
+```
+
 - a comma separated list of relative paths:
 
 ``` bash


### PR DESCRIPTION
The finder component allows for filtering on directories as well, but we didn't have it documented this was possible for infection.