### PR TITLE
Use the word "both" in the PHPUnit --coverage docs

### DIFF
--- a/src/guide/command-line-options.md
+++ b/src/guide/command-line-options.md
@@ -75,14 +75,14 @@ Path to the existing coverage reports.
 
 For `PHPUnit`:
 
-* Infection requires `xml` and `junit` reports
+* Infection requires both the`xml` and `junit` reports to work
 * If `build/coverage` path is provided, it should contain `coverage-xml` folder and `phpunit.junit.xml` file
   * `build/coverage/coverage-xml/*`
   * `build/coverage/phpunit.junit.xml`
   
 For `PhpSpec`:
 
-* Infection requires `xml` report
+* Infection requires the `xml` report to work
 * If `build/coverage` path is provided, it should contain `phpspec-coverage-xml` folder
 
 Example:


### PR DESCRIPTION
Hi, :wave: 

Here's my attempt to fix #41.

By inserting the word "both" in the sentence it should be more clear that both report types are required. I realize the issue described something about underlining the word "both".
If you still require this, please let me know.