### PR TITLE
Includes RoundFamily under Binary Arithmetic

### DIFF
--- a/src/guide/mutators.md
+++ b/src/guide/mutators.md
@@ -53,6 +53,12 @@ To verify that the visibility of a method is necessary. If the visibility of a m
 | Assignment | ^= | = |
 | Assignment | <<= | = |
 | Assignment | >>= | = |
+| RoundFamily | round | floor |
+| RoundFamily | round | ceil |
+| RoundFamily | ceil | floor |
+| RoundFamily | ceil | round |
+| RoundFamily | round | floor |
+| RoundFamily | round | ceil |
 
 ### Boolean Substitution
 

--- a/src/guide/mutators.md
+++ b/src/guide/mutators.md
@@ -53,12 +53,12 @@ To verify that the visibility of a method is necessary. If the visibility of a m
 | Assignment | ^= | = |
 | Assignment | <<= | = |
 | Assignment | >>= | = |
-| RoundFamily | round | floor |
-| RoundFamily | round | ceil |
-| RoundFamily | ceil | floor |
-| RoundFamily | ceil | round |
-| RoundFamily | round | floor |
-| RoundFamily | round | ceil |
+| RoundFamily | `round()` | `floor()` |
+| RoundFamily | `round()` | `ceil()` |
+| RoundFamily | `ceil()` | `floor()` |
+| RoundFamily | `ceil()` | `round()` |
+| RoundFamily | `round()` | `floor()` |
+| RoundFamily | `round()` | `ceil()` |
 
 ### Boolean Substitution
 


### PR DESCRIPTION
Docs for https://github.com/infection/infection/pull/449

I added it under Binary Arithmetic because the implementation is inside the Binary folder, however I also proposed #57 which seems to be a better fit for the docs, since these mutators act on function calls and not binary operators.