### PR TITLE
Documentation for Null Assignment Coalesce mutator

### DIFF
--- a/src/guide/mutators.md
+++ b/src/guide/mutators.md
@@ -96,6 +96,7 @@ The Unwrap* mutator family will unwrap function parameters.
 | Assignment | ^= | = |
 | Assignment | <<= | = |
 | Assignment | >>= | = |
+| Assignment Coalesce | ??= | = |
 
 ### Round Family
 

--- a/src/guide/profiles.md
+++ b/src/guide/profiles.md
@@ -152,8 +152,11 @@ Contains the following mutators:
 
 Contains the following mutators:
 
+* [AssignCoalesce](/guide/mutators.html#Binary-Arithmetic)
 * [Break_](/guide/mutators.html#Loop)
+* [Coalesce](/guide/mutators.html#Boolean-Substitution)
 * [Continue_](/guide/mutators.html#Loop)
+* [Finally_](/guide/mutators.html#Exceptions)
 * [Throw_](/guide/mutators.html#Exceptions)
 
 ### `@regex`


### PR DESCRIPTION
Also added missed mutators to the `@operator` profile

Doc for https://github.com/infection/infection/pull/641