### PR TITLE
Typo in ignored methods

### DIFF
--- a/src/guide/profiles.md
+++ b/src/guide/profiles.md
@@ -29,7 +29,7 @@ All profiles are prepended by an `@` and in snake case, while all mutators are i
         "@function_signature": false,
         "TrueValue": {
             "ignore": [
-                "NameSpace\\*\\SourceClass::method",
+                "NameSpace\\*\\SourceClass::create",
                 "Full\\NameSpaced\\Class"
             ]
         },


### PR DESCRIPTION
Method in doc doesn't match the method in config example.