### PR TITLE
added php compatibility matrix

### DIFF
--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -16,6 +16,12 @@ You can still use an older Infection version if you're running an older PHP Vers
 | 7.1 | 0.10 - 0.13 |
 | 7.0 | < 0.10 |
 
+<p class="tip">
+
+Please note that [Infection 0.13 isn't supported anymore](https://github.com/infection/infection/pull/809#issuecomment-556984454). Also note that [PHP 7.0 and 7.1 reached EOL](https://secure.php.net/supported-versions.php).
+
+</p>
+
 ## Phar
 
 Phar distribution is the best and recommended way of installing Infection on your computer.

--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -8,6 +8,14 @@ order: 2
 
 Infection requires PHP 7.2+, `XDebug`, `phpdbg` or `pcov` enabled.
 
+You can still use an older Infection version if you're running an older PHP Version.
+
+| PHP version | Infection version |
+|---|---|
+| 7.2.9+ | >= 0.14 |
+| 7.1 | 0.10 - 0.13 |
+| 7.0 | < 0.10 |
+
 ## Phar
 
 Phar distribution is the best and recommended way of installing Infection on your computer.


### PR DESCRIPTION
It's hard to see which infection version can be used with which PHP version, so I created a table based on the information in the release notes and in `composer.json`.

**PHP version 7.2 / infection >= 0.14**
* https://github.com/infection/infection/blob/0.14.0/composer.json#L45
* https://infection.github.io/2019/09/20/whats-new-in-0.14.0/

**PHP version 7.1 / infection >= 0.10**
* https://github.com/infection/infection/blob/0.10.0/composer.json#L60
* https://infection.github.io/2018/08/11/whats-new-in-0.10.0/

**PHP version 7.0 / infection < 0.10**
* https://github.com/infection/infection/blob/0.1.0/composer.json#L28