### PR TITLE
Update coverage example to output junit.xml

### DIFF
--- a/src/guide/command-line-options.md
+++ b/src/guide/command-line-options.md
@@ -98,7 +98,7 @@ Example:
 
 ```bash
 # collect coverage
-vendor/bin/phpunit --coverage-xml=build/coverage/coverage-xml --log-junit=build/coverage/phpunit.junit.xml
+vendor/bin/phpunit --coverage-xml=build/coverage/coverage-xml --log-junit=build/coverage/junit.xml
 
 # use coverage
 infection.phar --coverage=build/coverage


### PR DESCRIPTION
The filename requirements for junit coverage were recently changed from phpunit.junit.xml to junit.xml. The docs do specify the correct name however the example still uses the old name.