### PR TITLE
Fix incorrect mutator name: ConcatOperandRemoval

### DIFF
--- a/src/guide/mutators.md
+++ b/src/guide/mutators.md
@@ -239,7 +239,7 @@ infection.json:
 | FunctionCallRemoval | foo_bar($a) | -
 | MethodCallRemoval | $this->method($var) | -
 | CloneRemoval | clone (new stdClass()) | new stdClass()
-| ConcatOperatorRemoval | `'foo' . 'bar'` | `'bar'` and `'foo'`
+| ConcatOperandRemoval | `'foo' . 'bar'` | `'bar'` and `'foo'`
 | SharedCaseRemoval | `switch($a) { case 'a': case 'b': break; }` | `switch($a) { case 'b': break; }` `switch($a) { case 'a': break; }`
 
 #### `ArrayItemRemoval`


### PR DESCRIPTION
### Fixed
- The documentation was referring to the `ConcatOperandRemoval` mutator as `ConcatOperatorRemoval`