### PR TITLE
Update: PHP version mismatch composer requirement

### DIFF
--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -22,7 +22,7 @@ Infection is a **PHP mutation testing framework** based on AST (Abstract Syntax 
 
 > Read a [detailed post](https://medium.com/@maks_rafalko/infection-mutation-testing-framework-c9ccf02eefd1) about Mutation Testing and Infection on Medium
 
-Infection currently supports `PHPUnit`, `PhpSpec` and `Codeception` test frameworks, requires PHP 7.1+ and Xdebug/phpdbg/pcov installed.
+Infection currently supports `PHPUnit`, `PhpSpec` and `Codeception` test frameworks, requires PHP 7.4+ and Xdebug/phpdbg/pcov installed.
 
 In a nutshell, it 
 


### PR DESCRIPTION
In the documentation the recommended version for PHP was set to 7.1 and above, but in `composer.json` the requirement was already set to PHP 7.4 or 8.0. It's a small change, but at least it keeps the documentation in sync with the package requirements.