### PR TITLE
Add Docs for New Spread Mutators

### DIFF
--- a/src/guide/mutators.md
+++ b/src/guide/mutators.md
@@ -199,12 +199,14 @@ infection.json:
 
 | Name | Original | Mutated |
 | :------: | :------: |:-------:|
-| Spread | [...$collection, 2, 3] | [[...$collection][0], 2, 3] |
-| Coalesce | $foo ?? $bar | $bar ?? $foo |
-| Concat | $foo . $bar | $bar . $foo |
-| Ternary | isset($b) ? 'B' : 'C' | isset($b) ? 'C' : 'B' |
-| NullSafeMethodCall | $object?->getObject() | $object->getObject() |
-| NullSafePropertyCall | $object?->property | $object->property |
+| Coalesce | `$foo ?? $bar` | `$bar ?? $foo` |
+| Concat | `$foo . $bar` | `$bar . $foo` |
+| NullSafeMethodCall | `$object?->getObject()` | `$object->getObject()` |
+| NullSafePropertyCall | `$object?->property` | `$object->property` |
+| SpreadAssignment | `$array = [...$collection]` | `$array = $collection` |
+| SpreadOneItem | `[...$collection, 2, 3]` | `[[...$collection][0], 2, 3]` |
+| SpreadRemoval | `[...$collection, 2, 3]` | `[$collection, 2, 3]` |
+| Ternary | `isset($b) ? 'B' : 'C'` | `isset($b) ? 'C' : 'B'` |
 
 
 ### Increments

--- a/src/guide/profiles.md
+++ b/src/guide/profiles.md
@@ -185,7 +185,9 @@ Contains the following mutators:
 * [Coalesce](/guide/mutators.html#Boolean-Substitution)
 * [Continue_](/guide/mutators.html#Loop)
 * [Finally_](/guide/mutators.html#Exceptions)
-* [Spread](/guide/mutators.html#Operator)
+* [SpreadAssignment](/guide/mutators.html#Operator)
+* [SpreadOneItem](/guide/mutators.html#Operator)
+* [SpreadRemoval](/guide/mutators.html#Operator)
 * [Throw_](/guide/mutators.html#Exceptions)
 
 ### `@regex`


### PR DESCRIPTION
Related to: https://github.com/infection/infection/pull/1529

- [x] Adds `SpreadAssignment` + `SpreadRemoval`
- [x] Renames `Spread` to `SpreadOneItem`
- [x] Reorders Operator mutators lexicographically
- [x] Formatting tweaks