### PR TITLE
Documented `logs.badge.branch` accepting a regular expression

### DIFF
--- a/src/guide/mutation-badge.md
+++ b/src/guide/mutation-badge.md
@@ -32,15 +32,14 @@ Take these steps to enable the mutation score badge on your repository:
     {
         "logs": {
             "badge": {
-                "matchBranchRegex": "/^release-.*$/"
+                "branch": "/^release-.*$/"
             }
         }
     }
     ```
 
-    It is also possible to use `logs.badge.branch`, which does an exact match against your branch, should you wish
-    to run reporting against a single specific branch. Be aware that `branch` and `matchBranchRegex` are mutually 
-    exclusive:
+    If you provide a value that is not a regular expression starting and ending with `/`, a direct match will
+    be performed:
 
     ```json
     {

--- a/src/guide/mutation-badge.md
+++ b/src/guide/mutation-badge.md
@@ -32,7 +32,21 @@ Take these steps to enable the mutation score badge on your repository:
     {
         "logs": {
             "badge": {
-                "branch": "master"
+                "matchBranchRegex": "/^release-.*$/"
+            }
+        }
+    }
+    ```
+
+    It is also possible to use `logs.badge.branch`, which does an exact match against your branch, should you wish
+    to run reporting against a single specific branch. Be aware that `branch` and `matchBranchRegex` are mutually 
+    exclusive:
+
+    ```json
+    {
+        "logs": {
+            "badge": {
+                "branch": "main"
             }
         }
     }

--- a/src/guide/usage.md
+++ b/src/guide/usage.md
@@ -27,7 +27,7 @@ The first time you run Infection for your project, it will ask you several quest
         "perMutator": "per-mutator.md",
         "github": true,
         "badge": {
-            "branch": "master"
+            "matchBranchRegex": "/^master$/"
         }
     },
     "tmpDir": "/opt/tmp-folder",

--- a/src/guide/usage.md
+++ b/src/guide/usage.md
@@ -27,7 +27,7 @@ The first time you run Infection for your project, it will ask you several quest
         "perMutator": "per-mutator.md",
         "github": true,
         "badge": {
-            "matchBranchRegex": "/^master$/"
+            "branch": "/^release-.*$/"
         }
     },
     "tmpDir": "/opt/tmp-folder",


### PR DESCRIPTION
Replaced `logs.badge.branch` with `logs.badge.matchBranchRegex` in examples,
since it is much more powerful, and probably a better long-term solution
to more complex scenarios.

This patch complements https://github.com/infection/infection/pull/1538