### PR TITLE
Clarifying installation version number for PHP 7.4

### DIFF
--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -13,7 +13,7 @@ You can still use an older Infection version if you're using an older PHP versio
 | PHP version | Infection version |
 |--|---|
 | 8.0.0 | >= 0.26.7 |
-| 7.4.0 | >= 0.18 |
+| 7.4.0 | >= 0.18, <= 0.26.6 |
 | 7.3.12 | 0.16-0.17 |
 | 7.2.9+ | 0.14-0.15 |
 | 7.1 | 0.10 - 0.13 |


### PR DESCRIPTION
Following the instructions, I installed v0.26.13 on a PHP 7.4 project. I then ran into an incompatibility issue. 

The last compatible version for PHP 7.4 is 0.26.6, so I suggest it is reflected in the installation instructions for clarity.