### PR TITLE
Easy-accessible Playground URL

### DIFF
--- a/themes/infection/layout/index.ejs
+++ b/themes/infection/layout/index.ejs
@@ -15,6 +15,7 @@
       </h1>
       <p>
         <a class="button" href="<%- url_for("/guide/") %>">GET STARTED</a>
+        <a class="button white" href="https://infection-php.dev/" target="_blank">TRY IT!</a>
         <a class="button white" href="https://github.com/infection/infection" target="_blank">GITHUB</a>
       </p>
     </div>

--- a/themes/infection/layout/partials/main_menu.ejs
+++ b/themes/infection/layout/partials/main_menu.ejs
@@ -4,5 +4,6 @@
   </form>
 </li>
 <li><a href="<%- url_for("guide/") %>" class="nav-link<%- page.path.match(/guide/) ? ' current' : '' %>">Guide</a></li>
+<li><a href="https://infection-php.dev/" target="_blank">Playground</a></li>
 <li><a href="https://github.com/infection/infection" target="_blank">GitHub</a></li>
 <%- partial('partials/ecosystem_dropdown') %>


### PR DESCRIPTION
Tools like PHPStan or Psalm have easy-accessible playgrounds, while Infection has it described somewhere deep in the docs, which I personally find unnecessary. It's much better to have it directly on the landing page and always in top menu.