### PR TITLE
fix(how-to.md): broken link at how-to/By-using-git-diff-lines-option

### DIFF
--- a/src/guide/how-to.md
+++ b/src/guide/how-to.md
@@ -32,7 +32,7 @@ Useful to check how your changes impacts MSI in a feature branch. Useful for tho
 infection --git-diff-lines
 ```
 
-> [Read more](/guide/command-line-options.html#git-diff-lines) about [`--git-diff-lines`]((/guide/command-line-options.html#git-diff-lines)
+> [Read more](/guide/command-line-options.html#git-diff-lines) about [`--git-diff-lines`](/guide/command-line-options.html#git-diff-lines)
 
 ### By using `--filter` option (for the old Infection versions)
 


### PR DESCRIPTION
fixed: `Read more about --git-diff-lines` on https://infection.github.io/guide/how-to.html#By-using-git-diff-lines-option

I didn't see the same mistake anywhere else

https://github.com/search?q=repo%3Ainfection%2Fsite+%22%5D%28%28%22&type=code