### PR TITLE
Support dark theme

### DIFF
--- a/themes/infection/layout/layout.ejs
+++ b/themes/infection/layout/layout.ejs
@@ -61,6 +61,7 @@
         <!-- main custom script for sidebars, version selects etc. -->
         <script src="<%- url_for("/js/css.escape.js") %>"></script>
         <script src="<%- url_for("/js/common.js") %>"></script>
+        <script src="<%- url_for("/js/theme-switch.js") %>"></script>
 
         <!-- search -->
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />

--- a/themes/infection/layout/partials/main_menu.ejs
+++ b/themes/infection/layout/partials/main_menu.ejs
@@ -7,3 +7,4 @@
 <li><a href="https://infection-php.dev/" target="_blank">Playground</a></li>
 <li><a href="https://github.com/infection/infection" target="_blank">GitHub</a></li>
 <%- partial('partials/ecosystem_dropdown') %>
+<li><a id="theme-toggle" class="nav-link"><i class="theme-icon"></i></a></li>

--- a/themes/infection/layout/partials/main_menu.ejs
+++ b/themes/infection/layout/partials/main_menu.ejs
@@ -7,4 +7,4 @@
 <li><a href="https://infection-php.dev/" target="_blank">Playground</a></li>
 <li><a href="https://github.com/infection/infection" target="_blank">GitHub</a></li>
 <%- partial('partials/ecosystem_dropdown') %>
-<li><a id="theme-toggle" class="nav-link"><i class="theme-icon"></i></a></li>
+<li><a id="theme-toggle" style="cursor: pointer;"><i class="theme-icon"></i></a></li>

--- a/themes/infection/source/css/_common.styl
+++ b/themes/infection/source/css/_common.styl
@@ -1,5 +1,6 @@
 @import "_settings"
 @import "_syntax"
+@import '_dark-theme'
 
 body
     font-family $body-font

--- a/themes/infection/source/css/_dark-theme.styl
+++ b/themes/infection/source/css/_dark-theme.styl
@@ -18,13 +18,16 @@ $dark-code-text = #ff9e64
   background-position center
   vertical-align middle
 
+html:not(.dark-theme) .theme-icon,
 body:not(.dark-theme) .theme-icon
   background-image url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%232c3e50'%3E%3Cpath d='M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303a.75.75 0 00-1.061-1.06l-1.591 1.59a.75.75 0 001.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591z'%3E%3C/path%3E%3C/svg%3E")
 
+html.dark-theme .theme-icon,
 body.dark-theme .theme-icon
   background-image url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23eee'%3E%3Cpath fill-rule='evenodd' d='M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69.75.75 0 01.981.98 10.503 10.503 0 01-9.694 6.46c-5.799 0-10.5-4.701-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 01.818.162z' clip-rule='evenodd'%3E%3C/path%3E%3C/svg%3E")
 
 // Dark theme styles
+html.dark-theme,
 body.dark-theme
   background-color $dark-bg
   color $dark-medium-text

--- a/themes/infection/source/css/_dark-theme.styl
+++ b/themes/infection/source/css/_dark-theme.styl
@@ -101,6 +101,21 @@ body.dark-theme
         &:nth-child(2n)
           background-color lighten($dark-bg, 5%)
 
+  p.tip
+    background-color lighten($dark-bg, 5%)
+    border-left 4px solid $red
+    color $dark-text
+
+    &:before
+      background-color $red
+      color #fff
+
+    code
+      background-color $dark-codebg
+
+    em
+      color $dark-medium-text
+
   .footer
     color $dark-light-text
     border-top 1px solid $dark-border

--- a/themes/infection/source/css/_dark-theme.styl
+++ b/themes/infection/source/css/_dark-theme.styl
@@ -109,6 +109,8 @@ body.dark-theme
       tr
         &:nth-child(2n)
           background-color lighten($dark-bg, 5%)
+          code
+            background-color $dark-codebg
 
   p.tip
     background-color lighten($dark-bg, 5%)

--- a/themes/infection/source/css/_dark-theme.styl
+++ b/themes/infection/source/css/_dark-theme.styl
@@ -41,6 +41,20 @@ body.dark-theme
     &:hover, &.current
       border-bottom 3px solid $green
 
+  #nav
+    .nav-dropdown-container:hover .nav-dropdown
+      background-color $dark-header-bg
+      border-color $dark-border
+
+    .nav-dropdown
+      a
+        color $dark-medium-text
+        &:hover
+          color $green
+
+      h4
+        border-top 1px solid $dark-border
+
   h1, h2, h3, h4, strong
     color $dark-text
 

--- a/themes/infection/source/css/_dark-theme.styl
+++ b/themes/infection/source/css/_dark-theme.styl
@@ -1,0 +1,106 @@
+// Dark theme variables
+$dark-bg = #1b1b1f
+$dark-header-bg = #161618
+$dark-text = #dfdfd6
+$dark-medium-text = #ccc
+$dark-light-text = #999
+$dark-border = #444
+$dark-codebg = #161618
+$dark-code-text = #ff9e64
+
+// Theme toggle button styles
+.theme-icon
+  display inline-block
+  width 20px
+  height 20px
+  background-size contain
+  background-repeat no-repeat
+  background-position center
+  vertical-align middle
+
+body:not(.dark-theme) .theme-icon
+  background-image url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%232c3e50'%3E%3Cpath d='M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303a.75.75 0 00-1.061-1.06l-1.591 1.59a.75.75 0 001.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591z'%3E%3C/path%3E%3C/svg%3E")
+
+body.dark-theme .theme-icon
+  background-image url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23eee'%3E%3Cpath fill-rule='evenodd' d='M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69.75.75 0 01.981.98 10.503 10.503 0 01-9.694 6.46c-5.799 0-10.5-4.701-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 01.818.162z' clip-rule='evenodd'%3E%3C/path%3E%3C/svg%3E")
+
+// Dark theme styles
+body.dark-theme
+  background-color $dark-bg
+  color $dark-medium-text
+
+  #header
+    background-color $dark-header-bg
+    border-bottom 1px solid $dark-border
+
+  #logo
+    color $dark-text
+
+  .nav-link
+    color $dark-text
+    &:hover, &.current
+      border-bottom 3px solid $green
+
+  h1, h2, h3, h4, strong
+    color $dark-text
+
+  a
+    color $dark-medium-text
+
+  em
+    color $dark-light-text
+
+  code, pre
+    background-color $dark-codebg
+
+  code
+    color $dark-code-text
+
+  pre
+    color $dark-text
+
+  .highlight
+    background-color $dark-codebg
+
+  .search-query
+    background-color $dark-header-bg
+    color $dark-text
+    border-color $dark-border
+    background-image url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='none' stroke='%23ccc' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'%3E%3C/circle%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'%3E%3C/line%3E%3C/svg%3E")
+    background-repeat no-repeat
+    background-position 8px center
+    background-size 20px
+
+  #mobile-bar
+    background-color $dark-header-bg
+    box-shadow 0 0 2px rgba(0,0,0,.5)
+
+  .sidebar
+    background-color $dark-bg
+
+    .sidebar-link
+      color $dark-medium-text
+      &.current, &:hover
+        color $green
+        border-bottom 2px solid $green
+
+  .content
+    code
+      background-color $dark-codebg
+      color $dark-code-text
+
+    a
+      color $green
+
+    table
+      border-collapse collapse
+      display block
+      overflow-x auto
+
+      tr
+        &:nth-child(2n)
+          background-color lighten($dark-bg, 5%)
+
+  .footer
+    color $dark-light-text
+    border-top 1px solid $dark-border

--- a/themes/infection/source/css/_dark-theme.styl
+++ b/themes/infection/source/css/_dark-theme.styl
@@ -141,6 +141,22 @@ body.dark-theme
     em
       color $dark-medium-text
 
+  #hero
+    background-color $dark-bg
+
+    .left, .right
+      h1, h2
+        color $dark-text
+
+    .button
+      background-color lighten($green, 8%)
+      border-color lighten($green, 8%)
+      color #fff
+      &.white
+        background-color $dark-header-bg
+        color $green
+        border-color $green
+
   .footer
     color $dark-light-text
     border-top 1px solid $dark-border

--- a/themes/infection/source/css/_dark-theme.styl
+++ b/themes/infection/source/css/_dark-theme.styl
@@ -97,6 +97,15 @@ body.dark-theme
       display block
       overflow-x auto
 
+      td:not(td.code)
+        border 1px solid #2e2e32
+
+      th:not(.code th)
+        border 1px solid $dark-border
+        font-weight bold
+        text-align left
+        background-color lighten($dark-bg, 5%)
+
       tr
         &:nth-child(2n)
           background-color lighten($dark-bg, 5%)

--- a/themes/infection/source/js/theme-switch.js
+++ b/themes/infection/source/js/theme-switch.js
@@ -1,29 +1,39 @@
 (function() {
+  // On page load, set the theme
+  const userTheme = localStorage.getItem('theme');
+  const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+
+  if (userTheme === 'dark' || (!userTheme && systemTheme === 'dark')) {
+    document.documentElement.classList.add('dark-theme');
+    document.body.classList.add('dark-theme');
+  } else {
+    document.documentElement.classList.remove('dark-theme');
+    document.body.classList.remove('dark-theme');
+  }
+
   // Theme switching functionality
   document.addEventListener('DOMContentLoaded', function() {
     const themeToggle = document.getElementById('theme-toggle');
 
-    // Check for saved theme preference or respect OS preference
-    const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
-    const storedTheme = localStorage.getItem('theme');
+    // Function to toggle between light and dark mode
+    function toggleTheme() {
+      // Toggle dark class on html and body elements
+      const isDark = document.documentElement.classList.toggle('dark-theme');
+      document.body.classList.toggle('dark-theme', isDark);
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
 
-    // If the user has explicitly chosen a theme, use that
-    if (storedTheme) {
-      document.body.classList.toggle('dark-theme', storedTheme === 'dark');
-    }
-    // Otherwise, use the OS preference
-    else if (prefersDarkScheme.matches) {
-      document.body.classList.add('dark-theme');
-      localStorage.setItem('theme', 'dark');
+      // Dispatch custom event for Monaco editors
+      document.dispatchEvent(new CustomEvent('themeChanged'));
     }
 
     // Toggle theme when the button is clicked
-    themeToggle.addEventListener('click', function() {
-      document.body.classList.toggle('dark-theme');
+    themeToggle.addEventListener('click', toggleTheme);
 
-      // Update localStorage
-      const isDarkTheme = document.body.classList.contains('dark-theme');
-      localStorage.setItem('theme', isDarkTheme ? 'dark' : 'light');
+    // Listen for changes in system color scheme preference
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+      const isDark = event.matches;
+      document.documentElement.classList.toggle('dark-theme', isDark);
+      document.body.classList.toggle('dark-theme', isDark);
     });
   });
 })();

--- a/themes/infection/source/js/theme-switch.js
+++ b/themes/infection/source/js/theme-switch.js
@@ -1,0 +1,29 @@
+(function() {
+  // Theme switching functionality
+  document.addEventListener('DOMContentLoaded', function() {
+    const themeToggle = document.getElementById('theme-toggle');
+
+    // Check for saved theme preference or respect OS preference
+    const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
+    const storedTheme = localStorage.getItem('theme');
+
+    // If the user has explicitly chosen a theme, use that
+    if (storedTheme) {
+      document.body.classList.toggle('dark-theme', storedTheme === 'dark');
+    }
+    // Otherwise, use the OS preference
+    else if (prefersDarkScheme.matches) {
+      document.body.classList.add('dark-theme');
+      localStorage.setItem('theme', 'dark');
+    }
+
+    // Toggle theme when the button is clicked
+    themeToggle.addEventListener('click', function() {
+      document.body.classList.toggle('dark-theme');
+
+      // Update localStorage
+      const isDarkTheme = document.body.classList.contains('dark-theme');
+      localStorage.setItem('theme', isDarkTheme ? 'dark' : 'light');
+    });
+  });
+})();


### PR DESCRIPTION
Follow up for https://github.com/infection/playground/pull/11

Add support for dark them by AI (JetBrains Junie)

This code is in 99% written by UI (JetBrainsJunie) which is a nice experiment when Junie is released.

While the code quality is not perfect, I'm ok here as I explicitly didn't want to use any JS frameworks here. As simple as that and it does the work!

Light theme:

<img width="1502" alt="image" src="https://github.com/user-attachments/assets/087be267-8f4f-48c8-8986-6685d5fb4f90" />

Dark theme:

<img width="1489" alt="image" src="https://github.com/user-attachments/assets/bbeda1e9-cac3-4c64-addb-79dd63058c19" />
