### PR TITLE
Add Testo as a supported test framework in documentation

### DIFF
--- a/src/guide/command-line-options.md
+++ b/src/guide/command-line-options.md
@@ -58,7 +58,7 @@ infection -j$(sysctl -n hw.ncpu)
 
 ### `--test-framework`
 
-This is a name of the Test Framework to use. Currently, Infection supports `PHPUnit`, `PhpSpec` and `Codeception`.
+This is a name of the Test Framework to use. Currently, Infection supports `PHPUnit`, `PhpSpec`, `Codeception` and `Testo`.
 
 If you are using `infection/infection` Composer package, `PHPUnit` is installed by default. Other test framework adapters will be automatically installed on demand.
 [PHAR distribution](/guide/installation.html#Phar) is bundled with all available adapters.

--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -22,7 +22,7 @@ Infection is a **PHP mutation testing library** based on AST (Abstract Syntax Tr
 
 > Read a [detailed post](https://medium.com/@maks_rafalko/infection-mutation-testing-framework-c9ccf02eefd1) about Mutation Testing and Infection on Medium
 
-Infection currently supports `PHPUnit`, `PhpSpec` and `Codeception` test frameworks, requires PHP 7.4+ and Xdebug/phpdbg/pcov installed.
+Infection currently supports `PHPUnit`, `PhpSpec`, `Codeception` and `Testo` test frameworks, requires PHP 8.3+ and Xdebug/phpdbg/pcov installed.
 
 In a nutshell, it 
 

--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -10,20 +10,21 @@ Infection requires a recent version of PHP, and `Xdebug`, `phpdbg`, or `pcov` en
 
 You can still use an older Infection version if you're using an older PHP version. In that case, the following table must be considered:
 
-| PHP version | Infection version |
-|--|---|
-| 8.2.0 | >= 0.29.10 |
-| 8.1.0 | >= 0.26.16 |
-| 8.0.0 | >= 0.26.7 |
-| 7.4.0 | >= 0.18, <= 0.26.6 |
-| 7.3.12 | 0.16-0.17 |
-| 7.2.9+ | 0.14-0.15 |
-| 7.1 | 0.10 - 0.13 |
-| 7.0 | < 0.10 |
+| PHP version | Infection version  |
+|-------------|--------------------|
+| 8.3.0       | >= 0.32.7          |
+| 8.2.0       | >= 0.29.10         |
+| 8.1.0       | >= 0.26.16         |
+| 8.0.0       | >= 0.26.7          |
+| 7.4.0       | >= 0.18, <= 0.26.6 |
+| 7.3.12      | 0.16-0.17          |
+| 7.2.9+      | 0.14-0.15          |
+| 7.1         | 0.10 - 0.13        |
+| 7.0         | < 0.10             |
 
 ## Phar
 
-Phar distribution is the best and recommended way of installing Infection on your computer. Unlike `infection/infection`, it is bundled with all officially supported Test Frameworks: `PHPUnit`, `PhpSpec` and `Codeception`.
+Phar distribution is the best and recommended way of installing Infection on your computer. Unlike `infection/infection`, it is bundled with all officially supported Test Frameworks: `PHPUnit`, `PhpSpec`, `Codeception` and `Testo`.
 
 Download the latest `infection.phar` and `infection.phar.asc`:
 

--- a/src/guide/supported-test-frameworks.md
+++ b/src/guide/supported-test-frameworks.md
@@ -10,6 +10,7 @@ Infection supports the following Test Frameworks:
 * [PHPUnit](https://phpunit.readthedocs.io/en/latest/)
 * [PhpSpec](http://www.phpspec.net/en/stable/)
 * [Codeception](https://codeception.com/)
+* [Testo](https://php-testo.github.io/)
 
 If you are using [Phar distribution](/guide/installation.html#Phar) (downloading Phar or using [Phive](/guide/installation.html#Phive)), all the test frameworks are bundled into it.
 


### PR DESCRIPTION
If you don't mind, I'll update [this section](https://github.com/infection/site/blob/a45fef68e47ecc40247d36c3a1264d234b3fdc3e/src/guide/command-line-options.md?plain=1#L84-L112) later in a separate PR when I implement [JUnit support](https://github.com/php-testo/testo/issues/122) in Testo.

Docs for https://github.com/infection/infection/pull/3107