### PR TITLE
docs: Add --dots-per-row CLI option

### DIFF
--- a/src/guide/command-line-options.md
+++ b/src/guide/command-line-options.md
@@ -525,6 +525,21 @@ Example: `--static-analysis-tool-options="--memory-limit=-1 --stop-on-error"`.
 
 This is a name of console output formatter. Possible values are: `dot`, `progress`. Default is `dot` formatter.
 
+### `--dots-per-row`
+
+Number of dots per row in the dot progress formatter. Use `"max"` to fit the terminal width.
+
+Accepted values: a positive integer (e.g. `--dots-per-row=80`) or the literal `"max"` (e.g. `--dots-per-row=max`). Default is `50`. Only applies when the `dot` progress formatter is in use.
+
+```bash
+infection --dots-per-row=80
+infection --dots-per-row=max
+```
+
+With `"max"`, the formatter fits as many dots as the terminal width allows after reserving room for the `   (current / total)` suffix on the right, and never exceeds the total mutation count when it is known.
+
+> This option can also be set in [configuration file](/guide/usage.html) as `dotsPerRow`. The CLI flag takes precedence over the configuration file value.
+
 ### `--log-verbosity`
 
 The verbosity of the log file, `all` - this mode will add "Killed mutants" into log file and add additional information, `default` - normal mode will skip "Killed mutants" section in the log file, `none` - which will disable logging to files.

--- a/src/guide/usage.md
+++ b/src/guide/usage.md
@@ -69,6 +69,7 @@ The first time you run Infection for your project, it will ask you several quest
     },
     "timeoutsAsEscaped": true,
     "maxTimeouts": 10,
+    "dotsPerRow": 80,
     "testFramework":"phpunit",
     "testFrameworkOptions": "--filter=Unit",
     "staticAnalysisTool":"phpstan",
@@ -122,6 +123,7 @@ If you want to override settings locally, create and commit to VCS `infection.js
 * `minCoveredMsi` - optional key, a value for the Minimum Covered Code Mutation Score Indicator (MSI) percentage value
 * `timeoutsAsEscaped` - optional key, treats timed-out mutants as escaped in MSI calculation, giving an honest picture of test quality. See [`--with-timeouts`](/guide/command-line-options.html#with-timeouts)
 * `maxTimeouts` - optional key, maximum number of allowed timed-out mutants before the build fails. See [`--max-timeouts`](/guide/command-line-options.html#max-timeouts)
+* `dotsPerRow` - optional key, number of dots per row in the dot progress formatter. Accepts a positive integer or the literal `"max"` to fit the terminal width. Defaults to `50`. See [`--dots-per-row`](/guide/command-line-options.html#dots-per-row)
 * `mutators`: optional key, it contains the settings for different mutations and profiles, read more about it [here](/guide/profiles.html)
 * `testFramework`: optional key, it sets the framework to use for testing. Defaults to `phpunit`. This gets overridden by the `--test-framework` command line argument.
 * `testFrameworkOptions`: optional key, specify additional options to pass to the test framework (IE: Enabling Verbose Mode). `--test-framework-options` will override this option.


### PR DESCRIPTION
## Summary

- Documents the new `--dots-per-row` CLI option and its `dotsPerRow` config-file counterpart for configuring the dot progress formatter's row width (positive integer or `"max"` to fit terminal width)

Related: https://github.com/infection/infection/pull/3129